### PR TITLE
Use database table "dev_posts" if DEV set in environment variable PUBLIC_ENV; otherwise, use "posts"

### DIFF
--- a/src/lib/supabaseClient.js
+++ b/src/lib/supabaseClient.js
@@ -1,11 +1,16 @@
 import { createClient } from "@supabase/supabase-js";
 import { PUBLIC_SUPABASE_KEY, PUBLIC_SUPABASE_URL } from "$env/static/public";
 
+import { PUBLIC_ENV } from "$env/static/public";
+let table;
+
+PUBLIC_ENV === "DEV" ? (table = "dev_posts") : (table = "posts");
+
 export const supabase = createClient(PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_KEY);
 
 export async function getPostBySlug(slug) {
   const { data, error } = await supabase
-    .from("posts")
+    .from(table)
     .select()
     .eq("slug", slug)
     .neq("publishing_status", "deleted")
@@ -20,7 +25,7 @@ export async function getPostBySlug(slug) {
 
 export async function updatePostBySlug(slug, postContent, postTitle) {
   const { data, error } = await supabase
-    .from("posts")
+    .from(table)
     .update({ title: postTitle, body: postContent })
     .neq("publishing_status", "deleted")
     .eq("slug", slug);

--- a/src/routes/admin/+page.server.js
+++ b/src/routes/admin/+page.server.js
@@ -1,5 +1,9 @@
 import { supabase } from "$lib/supabaseClient";
 import { error, redirect } from "@sveltejs/kit";
+import { PUBLIC_ENV } from "$env/static/public";
+let table;
+
+PUBLIC_ENV === "DEV" ? (table = "dev_posts") : (table = "posts");
 
 export const prerender = false;
 
@@ -10,7 +14,7 @@ export async function load({ locals: { getSession } }) {
     // redirect(303, "/")
   } else {
     const { data } = await supabase
-      .from("posts")
+      .from(table)
       .select()
       .neq("publishing_status", "deleted");
     return {

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -3,13 +3,17 @@
   let { posts } = data;
   import dayjs from "dayjs";
   import { supabase } from "$lib/supabaseClient";
+  import { PUBLIC_ENV } from "$env/static/public";
+  let table;
+
+  PUBLIC_ENV === "DEV" ? (table = "dev_posts") : (table = "posts");
 
   async function deletePostBySlug(slug) {
     if (
       confirm(`Are you sure you want to delete the post with slug ${slug}?`)
     ) {
       const { error } = await supabase
-        .from("posts")
+        .from(table)
         .update({ publishing_status: "deleted" })
         .eq("slug", slug);
       if (!error) {
@@ -32,18 +36,34 @@
   <tbody>
     {#each posts as post}
         <tr>
-          <td><a href="/admin/{post.slug}">{post.title}</a> {#if post.publishing_status == 'draft'}<span class="badge bg-secondary">Draft</span>{:else if post.publishing_status == 'published'}<span class="badge bg-success">Published</span>{/if}</td>
+          <td
+            ><a href="/admin/{post.slug}">{post.title}</a>
+            {#if post.publishing_status == "draft"}<span
+                class="badge bg-secondary">Draft</span
+              >{:else if post.publishing_status == "published"}<span
+                class="badge bg-success">Published</span
+              >{/if}</td
+          >
           <td>{dayjs(post.created_at).format("DD/MM/YYYY")}</td>
           <td>{dayjs(post.updated_at).format("DD/MM/YYYY hh:mm:ss")}</td>
           <td>
-            <a class="btn btn-danger" role='button' href="/admin/" on:click={() => deletePostBySlug(post.slug)}>Delete</a>
+            <a
+              class="btn btn-danger"
+              role="button"
+              href="/admin/"
+              on:click={() => deletePostBySlug(post.slug)}>Delete</a
+            >
           </td>
         </tr>
       {/each}
-  </tbody>
-</table>
+    </tbody>
+  </table>
 {:else}
-<p>There are no posts to show, but you can create a <a href="/admin/new">New Post</a>!</p>
+  <p>
+    There are no posts to show, but you can create a <a href="/admin/new"
+      >New Post</a
+    >!
+  </p>
 {/if}
 
 <style>

--- a/src/routes/admin/[slug]/+page.server.js
+++ b/src/routes/admin/[slug]/+page.server.js
@@ -6,6 +6,11 @@ export const load = ({ params }) => {
   return data;
 };
 
+import { PUBLIC_ENV } from "$env/static/public";
+let table;
+
+PUBLIC_ENV === "DEV" ? (table = "dev_posts") : (table = "posts");
+
 import { fail, redirect } from "@sveltejs/kit";
 
 export const actions = {
@@ -17,7 +22,7 @@ export const actions = {
     const status = formData.get("status");
     const updated_at = getCurrentDateTime();
     const { error } = await supabase
-      .from("posts")
+      .from(table)
       .update({
         title: title,
         body: body,

--- a/src/routes/admin/new/+page.server.js
+++ b/src/routes/admin/new/+page.server.js
@@ -2,6 +2,10 @@ import { supabase } from "$lib/supabaseClient";
 
 export const prerender = false;
 import { fail, redirect } from "@sveltejs/kit";
+import { PUBLIC_ENV } from "$env/static/public";
+let table;
+
+PUBLIC_ENV === "DEV" ? (table = "dev_posts") : (table = "posts");
 
 export const actions = {
   default: async ({ request }) => {
@@ -23,7 +27,7 @@ export const actions = {
     // }
 
     const { count } = await supabase
-      .from("posts")
+      .from(table)
       .select("*", { count: "exact", head: true })
       .eq("slug", slug);
 
@@ -34,7 +38,7 @@ export const actions = {
     const body = formData.get("hiddenBody");
     const status = formData.get("status");
 
-    const { error } = await supabase.from("posts").insert({
+    const { error } = await supabase.from(table).insert({
       title: title,
       body: body,
       slug: slug,

--- a/src/routes/posts/+page.server.js
+++ b/src/routes/posts/+page.server.js
@@ -1,8 +1,12 @@
 import { supabase } from "$lib/supabaseClient";
+import { PUBLIC_ENV } from "$env/static/public";
+let table;
+
+PUBLIC_ENV === "DEV" ? (table = "dev_posts") : (table = "posts");
 
 export async function load() {
   const { data } = await supabase
-    .from("posts")
+    .from(table)
     .select()
     .eq("publishing_status", "published");
   return {


### PR DESCRIPTION
This PR adds support for a development or staging "posts" table. The appropriate table is used depending on whether the PUBLIC_ENV environment variable is set to "DEV" or not.