### PR TITLE
Display photography from Bluesky feed

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -26,16 +26,19 @@
     await goto("/");
   };
 
-  let menuItems = $derived([
-    { linkText: "Home", url: "/", id: "0" },
-    { linkText: "Posts", id: "2" },
-  ].map((item) => ({
-    ...item,
-    url:
-      item.linkText !== "Home"
-        ? `/${item.linkText.replaceAll(" ", "-").toLowerCase()}`
-        : item.url,
-  })));
+  let menuItems = $derived(
+    [
+      { linkText: "Home", url: "/", id: "0" },
+      { linkText: "Posts", id: "2" },
+      { linkText: "Photos", id: "3" },
+    ].map((item) => ({
+      ...item,
+      url:
+        item.linkText !== "Home"
+          ? `/${item.linkText.replaceAll(" ", "-").toLowerCase()}`
+          : item.url,
+    }))
+  );
 </script>
 
 <svelte:head>

--- a/src/routes/photos/+page.server.js
+++ b/src/routes/photos/+page.server.js
@@ -1,0 +1,84 @@
+import { BLUESKY_USERNAME, BLUESKY_APP_PASSWORD } from "$env/static/private";
+
+export async function load() {
+  const BLUESKY_API_BASE = "https://bsky.social/xrpc";
+  const userDid = BLUESKY_USERNAME;
+
+  try {
+    //Authenticate with Bluesky
+    const authResponse = await fetch(
+      `${BLUESKY_API_BASE}/com.atproto.server.createSession`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          identifier: BLUESKY_USERNAME,
+          password: BLUESKY_APP_PASSWORD,
+        }),
+      }
+    );
+
+    if (!authResponse.ok) {
+      throw new Error(`Authentication failed: ${authResponse.status}`);
+    }
+
+    const authData = await authResponse.json();
+    const { accessJwt, did } = authData;
+
+    //Make a request to get the user's feed
+    const params = new URLSearchParams({
+      actor: userDid,
+      limit: 50,
+    });
+
+    const feedResponse = await fetch(
+      `${BLUESKY_API_BASE}/app.bsky.feed.getAuthorFeed?${params}`,
+      {
+        headers: {
+          Authorization: `Bearer ${accessJwt}`,
+        },
+      }
+    );
+
+    if (!feedResponse.ok) {
+      throw new Error(`API request failed: ${feedResponse.status}`);
+    }
+
+    const data = await feedResponse.json();
+
+    // Filter posts that:
+    // 1. Contain "#photography" hashtag
+    // 2. Contain images
+    // 3. Are not reposts
+    const photographyPosts = data.feed.filter((item) => {
+      // Skip reposts
+      if (item.reason) {
+        return false;
+      }
+
+      const post = item.post;
+      const text = post.record.text || "";
+
+      // Check for #photography hashtag
+      const hasPhotographyTag = text.toLowerCase().includes("#photography");
+
+      // Check for images
+      const hasImages =
+        post.embed && post.embed.images && post.embed.images.length > 0;
+
+      return hasPhotographyTag && hasImages;
+    });
+
+    return {
+      photographyPosts,
+    };
+  } catch (error) {
+    console.error("Error fetching Bluesky data:", error);
+    return {
+      error: error.message,
+      photographyPosts: [],
+    };
+  }
+}

--- a/src/routes/photos/+page.server.js
+++ b/src/routes/photos/+page.server.js
@@ -68,6 +68,14 @@ export async function load() {
       const hasImages =
         post.embed && post.embed.images && post.embed.images.length > 0;
 
+      // Extract alt text if available (new code)
+      if (hasImages && post.embed.images) {
+        post.embed.images.forEach((img) => {
+          // Alt text is available in the 'alt' property if it exists
+          img.altText = img.alt || "";
+        });
+      }
+
       return hasPhotographyTag && hasImages;
     });
 

--- a/src/routes/photos/+page.svelte
+++ b/src/routes/photos/+page.svelte
@@ -1,0 +1,175 @@
+<script>
+  export let data;
+
+  const { photographyPosts, error } = data;
+
+  // Function to handle image click for expanded view (optional)
+  function handleImageClick(post) {
+    // You could implement a modal or expanded view here
+    console.log("Image clicked:", post);
+  }
+</script>
+
+<div class="photography-feed">
+  <h1>Photography Posts</h1>
+
+  {#if error}
+    <div class="error">
+      <p>Error loading posts: {error}</p>
+    </div>
+  {:else if photographyPosts.length === 0}
+    <p>No photography posts found.</p>
+  {:else}
+    <!-- Instagram-style grid layout -->
+    <div class="instagram-grid">
+      {#each photographyPosts as post}
+        {#each post.post.embed.images as image, imageIndex}
+          <!-- Each image becomes a grid item -->
+          <div
+            class="grid-item"
+            on:click={() => handleImageClick(post)}
+            on:keydown={(e) => e.key === "Enter" && handleImageClick(post)}
+            tabindex="0"
+          >
+            <img
+              src={image.fullsize}
+              alt={`Photo by @${post.post.author.handle}`}
+              loading="lazy"
+              class="grid-image"
+            />
+
+            <!-- Hover overlay with info -->
+            <div class="overlay">
+              <div class="overlay-content">
+                <div class="author-info">
+                  {#if post.post.author.avatar}
+                    <img
+                      src={post.post.author.avatar}
+                      alt="Profile"
+                      class="avatar"
+                    />
+                  {/if}
+                  <span class="author-name">@{post.post.author.handle}</span>
+                </div>
+
+                <!-- Show truncated text as a caption -->
+                {#if post.post.record.text}
+                  <p class="caption">
+                    {post.post.record.text.length > 60
+                      ? post.post.record.text.substring(0, 60) + "..."
+                      : post.post.record.text}
+                  </p>
+                {/if}
+              </div>
+            </div>
+          </div>
+        {/each}
+      {/each}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .photography-feed {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 20px;
+  }
+
+  h1 {
+    margin-bottom: 20px;
+    text-align: center;
+  }
+
+  /* Instagram-style grid */
+  .instagram-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 4px;
+  }
+
+  @media (max-width: 768px) {
+    .instagram-grid {
+      grid-template-columns: repeat(2, 1fr);
+    }
+  }
+
+  @media (max-width: 480px) {
+    .instagram-grid {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  .grid-item {
+    position: relative;
+    aspect-ratio: 1/1;
+    overflow: hidden;
+    cursor: pointer;
+  }
+
+  .grid-image {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    transition: transform 0.3s ease;
+  }
+
+  /* Hover effects */
+  .grid-item:hover .grid-image {
+    transform: scale(1.05);
+  }
+
+  .grid-item:hover .overlay {
+    opacity: 1;
+  }
+
+  .overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    padding: 15px;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+    color: white;
+  }
+
+  .author-info {
+    display: flex;
+    align-items: center;
+    margin-bottom: 8px;
+  }
+
+  .avatar {
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    margin-right: 8px;
+    border: 1px solid white;
+  }
+
+  .author-name {
+    font-weight: bold;
+    font-size: 0.9rem;
+  }
+
+  .caption {
+    margin: 0;
+    font-size: 0.85rem;
+    line-height: 1.4;
+  }
+
+  .error {
+    color: red;
+    padding: 10px;
+    border: 1px solid red;
+    border-radius: 4px;
+    background: rgba(255, 0, 0, 0.05);
+    margin-bottom: 20px;
+  }
+</style>

--- a/src/routes/photos/+page.svelte
+++ b/src/routes/photos/+page.svelte
@@ -11,7 +11,18 @@
 </script>
 
 <div class="photography-feed">
-  <h1>Photography Posts</h1>
+  <h1>Photography</h1>
+  <p>
+    This page automatically displays any photos I've taken and posted to bluesky
+    (<a href="https://bsky.app/profile/dvln.xyz">@dvln.xyz</a>) with the
+    <a href="https://bsky.app/hashtag/photography">#photography</a> tag.
+  </p>
+  <div class="error">
+    <p>
+      ¯\_(ツ)_/¯ This page is still a work in progress at the moment, and isn't
+      reliably displaying all images from my bluesky feed.
+    </p>
+  </div>
 
   {#if error}
     <div class="error">

--- a/src/routes/photos/+page.svelte
+++ b/src/routes/photos/+page.svelte
@@ -36,15 +36,10 @@
       {#each photographyPosts as post}
         {#each post.post.embed.images as image, imageIndex}
           <!-- Each image becomes a grid item -->
-          <div
-            class="grid-item"
-            on:click={() => handleImageClick(post)}
-            on:keydown={(e) => e.key === "Enter" && handleImageClick(post)}
-            tabindex="0"
-          >
+          <div class="grid-item" on:click={() => handleImageClick(post)}>
             <img
               src={image.fullsize}
-              alt={`Photo by @${post.post.author.handle}`}
+              alt={image.altText || `Photo by @${post.post.author.handle}`}
               loading="lazy"
               class="grid-image"
             />


### PR DESCRIPTION
This PR adds the /photos page.

It pulls in myBluesky feed, and filters it down to just the posts containing images and the hashtag #photography. It also excludes reposts.

Images are then displayed in a grid on the front end.